### PR TITLE
[Squash-and-merge] add github actions recipe to build on linux

### DIFF
--- a/.github/workflows/linux_build_libretro.yml
+++ b/.github/workflows/linux_build_libretro.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Install needed packages
-      run: sudo apt install wget git build-essential
+      run: sudo apt install wget git build-essential liblzma-dev libgl-dev zlib1g-dev
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
### Description of Changes
Just adds a recipe that will try to build on linux when there's a PR or a push to the libretroization branch.

### Rationale behind Changes
So we can keep an eye on build breakages.
