### PR TITLE
Fix build with older versions of Xcode

### DIFF
--- a/common/AlignedMalloc.cpp
+++ b/common/AlignedMalloc.cpp
@@ -19,7 +19,9 @@
 #if !defined(_WIN32)
 
 #include "common/AlignedMalloc.h"
-#include <stdlib.h>
+
+#include <algorithm>
+#include <cstdlib>
 
 void* _aligned_malloc(size_t size, size_t align)
 {


### PR DESCRIPTION
From https://github.com/PCSX2/pcsx2/commit/31e9206fc0a8284fb799248f72364c863375b715, to correctly pick up definition of `std::min`.