### PR TITLE
Mipmapping core option (GSdx)

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -195,6 +195,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "1x Native (PS2)"
    },
+   {
+      "pcsx2_mipmapping",
+      "Mipmapping (Restart)",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "enabled", NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
 #if 0
    {
       "pcsx2_sw_renderer_threads",


### PR DESCRIPTION
* Added a separate "Mipmapping" core option for GSdx, easier to manage with a clear distinction between plugins.
* Fixed initialization of HW mipmaps with GSdx, before it was starting in "Unclamped" mode, instead of "Enabled", easy to check with Ratchet & Clank:
  - before:
  ![image](https://github.com/user-attachments/assets/d88cb3db-1c89-499a-b539-34e70643fb85)
  - after:
  ![image](https://github.com/user-attachments/assets/9e8e7904-9b87-480f-9776-efaad65d0a08)
* Delayed the first `check_variables()` a bit, so we can use the `SetxxxValue()` functions direcly from it on boot in the future if needed.
