### PR TITLE
Big core options cleanups/modifications

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -151,7 +151,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx2_pgs_ssaa",
-      "paraLLEl super sampling (Restart)",
+      "paraLLEl super sampling",
       NULL,
       NULL,
       NULL,
@@ -169,7 +169,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx2_pgs_high_res_scanout",
-      "paraLLEl experimental High-res scanout (Restart)",
+      "paraLLEl experimental High-res scanout",
       NULL,
       NULL,
       NULL,
@@ -183,7 +183,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx2_pgs_disable_mipmaps",
-      "paraLLEl force texture LOD0 (Restart)",
+      "paraLLEl force texture LOD0",
       NULL,
       NULL,
       NULL,
@@ -197,7 +197,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx2_upscale_multiplier",
-      "Internal Resolution",
+      "Internal Resolution (Restart)",
       NULL,
       NULL,
       NULL,
@@ -225,7 +225,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx2_mipmapping",
-      "Mipmapping (Restart)",
+      "Mipmapping",
       NULL,
       NULL,
       NULL,
@@ -245,16 +245,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "video",
       {
-         {"Automatic", NULL },
-         {"Off", NULL },
-         {"WeaveTFF", NULL },
-         {"WeaveBFF", NULL },
-         {"BobTFF", NULL },
-         {"BobBFF", NULL },
-         {"BlendTFF", NULL },
-         {"BlendBFF", NULL },
-         {"AdaptiveTFF", NULL },
-         {"AdaptiveBFF", NULL },
+         { "Automatic", NULL },
+         { "Off", NULL },
+         { "Weave TFF", NULL },
+         { "Weave BFF", NULL },
+         { "Bob TFF", NULL },
+         { "Bob BFF", NULL },
+         { "Blend TFF", NULL },
+         { "Blend BFF", NULL },
+         { "Adaptive TFF", NULL },
+         { "Adaptive BFF", NULL },
          { NULL, NULL },
       },
       "Automatic"
@@ -271,7 +271,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "disabled", NULL },
          { NULL, NULL },
       },
-      "disabled"
+      "enabled"
    },
 #if 0
    {

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -44,7 +44,6 @@
 #include "VMManager.h"
 
 /* TODO/FIXME - forward declaration */
-extern bool pcsx2_fastcdvd;
 extern MemorySettingsInterface s_settings_interface;
 
 // This typically reflects the Sony-assigned serial code for the Disc, if one exists.
@@ -68,7 +67,7 @@ static void CDVDSECTORREADY_INT(u32 eCycle)
 	if (psxRegs.interrupt & (1 << IopEvt_CdvdSectorReady))
 		return;
 
-	if (pcsx2_fastcdvd)
+	if (EmuConfig.Speedhacks.fastCDVD)
 	{
 		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
 			eCycle *= 0.05f;
@@ -81,7 +80,7 @@ static void CDVDREAD_INT(u32 eCycle)
 {
 	// Give it an arbitary FAST value. Good for ~5000kb/s in ULE when copying a file from CDVD to HDD
 	// Keep long seeks out though, as games may try to push dmas while seeking. (Tales of the Abyss)
-	if (pcsx2_fastcdvd)
+	if (EmuConfig.Speedhacks.fastCDVD)
 	{
 		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
 			eCycle *= 0.05f;

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -839,6 +839,7 @@ struct Pcsx2Config
 		struct
 		{
 			bool EnablePatches : 1, // enables patch detection and application
+			     EnableCheats  : 1, // enables cheat detection and application
 			     EnableWideScreenPatches    : 1,
 			     EnableNoInterlacingPatches : 1,
 		             EnableGameFixes            : 1, // enables automatic game fixes

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -926,6 +926,7 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapSection("EmuCore");
 
 	SettingsWrapBitBool(EnablePatches);
+	SettingsWrapBitBool(EnableCheats);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
 	SettingsWrapBitBool(EnableGameFixes);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -22,7 +22,6 @@
 #include <fmt/format.h>
 
 #include <file/file_path.h>
-#include <libretro.h>
 
 #include "common/Console.h"
 #include "common/FileSystem.h"
@@ -65,8 +64,6 @@
 #include <objbase.h>
 #include <timeapi.h>
 #endif
-
-extern retro_environment_t environ_cb;
 
 // Resets all PS2 cpu execution caches, which does not affect that actual PS2 state/condition.
 // This can be called at any time outside the context of a Cpu->Execute() block without
@@ -296,7 +293,6 @@ bool VMManager::UpdateGameSettingsLayer(void) { return true; }
 
 void VMManager::LoadPatches(const std::string& serial, u32 crc)
 {
-	struct retro_variable var;
 	std::string message;
 	int patch_count = 0;
 	const std::string crc_string(fmt::format("{:08X}", crc));
@@ -323,10 +319,7 @@ void VMManager::LoadPatches(const std::string& serial, u32 crc)
 
 	// regular cheat patches
 	int cheat_count = 0;
-
-	var.key = "pcsx2_enable_cheats";
-
-	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "enabled"))
+	if (EmuConfig.EnableCheats)
 	{
 		cheat_count = LoadPatchesFromDir(crc_string, EmuFolders::Cheats, "Cheats", true);
 		if (cheat_count > 0)
@@ -961,7 +954,7 @@ void VMManager::CheckForFramerateConfigChanges(const Pcsx2Config& old_config)
 
 void VMManager::CheckForPatchConfigChanges(const Pcsx2Config& old_config)
 {
-	if (
+	if (EmuConfig.EnableCheats == old_config.EnableCheats &&
 		EmuConfig.EnableWideScreenPatches == old_config.EnableWideScreenPatches &&
 		EmuConfig.EnablePatches == old_config.EnablePatches)
 		return;
@@ -1035,7 +1028,7 @@ void VMManager::CheckForConfigChanges(const Pcsx2Config& old_config)
 		CheckForMemoryCardConfigChanges(old_config);
 		USB::CheckForConfigChanges(old_config);
 
-		if (
+		if (EmuConfig.EnableCheats != old_config.EnableCheats ||
 			EmuConfig.EnableWideScreenPatches != old_config.EnableWideScreenPatches ||
 			EmuConfig.EnableNoInterlacingPatches != old_config.EnableNoInterlacingPatches)
 			VMManager::ReloadPatches();


### PR DESCRIPTION
* No restart needed for graphical options (minus internal res due to crashes/glitches).
* Stop messing with EmuConfig.GS/GSConfig, simply use `SetxxxValue()` followed by `ApplySettings()`, it will fill these vars automatically.
* Reverted changes from CDVD.cpp and VMManager.cpp, because of the above we have absolutely no need to mess with these (I left your 0.5f -> 0.05f changes however).

Example with cheats, to "prove" that it works fine without messing with the EmuConfig stuff:

https://github.com/user-attachments/assets/b0149dfd-a495-41c0-92ba-46532211035f

