### PR TITLE
Add EE cycle core options

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -61,6 +61,11 @@ struct retro_core_option_v2_category option_cats_us[] = {
       "Show video options."
    },
    {
+      "emulation",
+      "Emulation",
+      "Show emulation options"
+   },
+   {
       "input",
       "Input",
       "Show input options."
@@ -283,6 +288,41 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "2"
    },
 #endif
+   {
+      "pcsx2_ee_cycle_rate",
+      "EE Cycle Rate",
+      NULL,
+      NULL,
+      NULL,
+      "emulation",
+      {
+         { "50% (Underclock)", NULL },
+         { "60% (Underclock)", NULL },
+         { "75% (Underclock)", NULL },
+         { "100% (Normal Speed)", NULL },
+         { "130% (Overclock)", NULL },
+         { "180% (Overclock)", NULL },
+         { "300% (Overclock)", NULL },
+         { NULL, NULL },
+      },
+      "100% (Normal Speed)"
+   },
+   {
+      "pcsx2_ee_cycle_skip",
+      "EE Cycle Skipping",
+      NULL,
+      NULL,
+      NULL,
+      "emulation",
+      {
+         { "disabled", NULL },
+         { "Mild Underclock", NULL },
+         { "Moderate Underclock", NULL },
+         { "Maximum Underclock", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
    {
       "pcsx2_axis_scale1",
       "Port 1: Analog Sensitivity",

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -92,7 +92,8 @@ static u8 pgs_super_sampling;
 static u8 pgs_high_res_scanout;
 static u8 pgs_disable_mipmaps;
 static u8 deinterlace_mode;
-static bool mipmapping;
+static u8 ee_clycle_skip;
+static s8 ee_clycle_rate;
 static bool pcrtc_antiblur;
 static bool enable_cheats;
 float pad_axis_scale[2];
@@ -322,12 +323,9 @@ static void check_variables(bool first_run)
 			else if (!strcmp(var.value, "Adaptive BFF"))
 				deinterlace_mode = (u8)GSInterlaceMode::AdaptiveBFF;
 
-			if (deinterlace_mode != i_prev && !first_run)
-			{
-				s_settings_interface.SetIntValue("EmuCore/GS", "deinterlace_mode", deinterlace_mode);
-				if (deinterlace_mode != i_prev)
-					apply_settings_requested = true;
-			}
+			s_settings_interface.SetIntValue("EmuCore/GS", "deinterlace_mode", deinterlace_mode);
+			if (deinterlace_mode != i_prev)
+				apply_settings_requested = true;
 		}
 	}
 
@@ -369,6 +367,48 @@ static void check_variables(bool first_run)
 
 		s_settings_interface.SetBoolValue("EmuCore", "EnableCheats", enable_cheats);
 		if (!!enable_cheats != i_prev)
+			apply_settings_requested = true;
+	}
+
+	var.key = "pcsx2_ee_cycle_rate";
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+	{
+		i_prev = ee_clycle_rate;
+		if (!strcmp(var.value, "50% (Underclock)"))
+			ee_clycle_rate = -3;
+		else if (!strcmp(var.value, "60% (Underclock)"))
+			ee_clycle_rate = -2;
+		else if (!strcmp(var.value, "75% (Underclock)"))
+			ee_clycle_rate = -1;
+		else if (!strcmp(var.value, "100% (Normal Speed)"))
+			ee_clycle_rate = 0;
+		else if (!strcmp(var.value, "130% (Overclock)"))
+			ee_clycle_rate = 1;
+		else if (!strcmp(var.value, "180% (Overclock)"))
+			ee_clycle_rate = 2;
+		else if (!strcmp(var.value, "300% (Overclock)"))
+			ee_clycle_rate = 3;
+
+		s_settings_interface.SetIntValue("EmuCore/Speedhacks", "EECycleRate", ee_clycle_rate);
+		if (ee_clycle_rate != i_prev)
+			apply_settings_requested = true;
+	}
+
+	var.key = "pcsx2_ee_cycle_skip";
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+	{
+		i_prev = ee_clycle_skip;
+		if (!strcmp(var.value, "disabled"))
+			ee_clycle_skip = 0;
+		else if (!strcmp(var.value, "Mild Underclock"))
+			ee_clycle_skip = 1;
+		else if (!strcmp(var.value, "Moderate Underclock"))
+			ee_clycle_skip = 2;
+		else if (!strcmp(var.value, "Maximum Underclock"))
+			ee_clycle_skip = 3;
+
+		s_settings_interface.SetIntValue("EmuCore/Speedhacks", "EECycleSkip", ee_clycle_skip);
+		if (ee_clycle_skip != i_prev)
 			apply_settings_requested = true;
 	}
 


### PR DESCRIPTION
Add EE Cycle Rate/Skip core options, also fixed deinterlace mode that wouldn't be applied on boot, and removed a leftover bool from previous PR.