### PR TITLE
PGS: geometry fix

### DIFF
--- a/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.cpp
+++ b/pcsx2/GS/Renderers/parallel-gs/GSRendererPGS.cpp
@@ -510,7 +510,7 @@ void GSRendererPGS::VSync(u32 field, bool registers_written)
 	{
 		if (vsync.image)
 		{
-			retro_game_geometry geom = {};
+			static retro_game_geometry geom  = {};
 			bool geom_changed                = false;
 			static float last_aspect         = 0.0f;
 			static uint32_t last_base_width  = 0;


### PR DESCRIPTION
Simple fix so width doesn't reset to 0 every time height changes, and vice-versa.

So now when width or height gets updated, stuff like this:

![image](https://github.com/user-attachments/assets/dbf85f20-04ba-409d-a8df-0683fec44e60)

will now display properly:

![image](https://github.com/user-attachments/assets/279b513b-8e8e-41ff-a435-130972ae9e53)
