### PR TITLE
Partially revert a commit to fix rendering for certain games.

### DIFF
--- a/pcsx2/x86/ix86-32/recVTLB.cpp
+++ b/pcsx2/x86/ix86-32/recVTLB.cpp
@@ -493,7 +493,7 @@ int vtlb_DynGenReadNonQuad_Const(u32 bits, bool sign, bool xmm, u32 addr_const, 
 
 int vtlb_DynGenReadQuad(u32 bits, int addr_reg, vtlb_ReadRegAllocCallback dest_reg_alloc)
 {
-	const int reg = dest_reg_alloc ? dest_reg_alloc() : (_freeXMMreg(0), 0); // Handler returns in xmm0
+	int reg;
 	if (!CHECK_FASTMEM || vtlb_IsFaultingPC(pc))
 	{
 		iFlushCall(FLUSH_FULLVTLB);
@@ -501,12 +501,17 @@ int vtlb_DynGenReadQuad(u32 bits, int addr_reg, vtlb_ReadRegAllocCallback dest_r
 		DynGen_PrepRegs(arg1regd.Id, -1, bits, true);
 		DynGen_HandlerTest([bits]() {DynGen_DirectRead(bits, false); },  0, bits);
 
+		/* The call here needs to be after the above function calls. */
+		reg = dest_reg_alloc ? dest_reg_alloc() : (_freeXMMreg(0), 0); /* Handler returns in xmm0 */
+
 		if (reg >= 0)
 			xMOVAPS(xRegisterSSE(reg), xmm0);
 	}
 	else
 	{
 		const u8* codeStart = x86Ptr;
+
+		reg = dest_reg_alloc ? dest_reg_alloc() : (_freeXMMreg(0), 0); /* Handler returns in xmm0 */
 
 		xMOVAPS(xRegisterSSE(reg), ptr128[RFASTMEMBASE + arg1reg]);
 

--- a/pcsx2/x86/microVU_Misc.inl
+++ b/pcsx2/x86/microVU_Misc.inl
@@ -268,7 +268,7 @@ __fi void mVUrestoreRegs(microVU& mVU, bool fromMemory = false, bool onlyNeeded 
 
 static void mVUTBit(void)
 {
-	u32 old = vu1Thread.mtvuInterrupts.fetch_or(VU_Thread::InterruptFlagVUTBit, std::memory_order_release);
+	vu1Thread.mtvuInterrupts.fetch_or(VU_Thread::InterruptFlagVUTBit, std::memory_order_release);
 }
 
 static void mVUEBit(void)


### PR DESCRIPTION
This patch partially reverts commit 2dc2aca from November 11, 2025 to restore functional rendering with certain game engines; I've only found a few games that are broken with the earlier commit, but I only have about sixty PlayStation II games available to test.

I tested this patch for around six hours with several different games, and I believe the patch to be safe; the earlier commit seems to be born of a decision to move code around to pacify certain compilers, but a few of the lines have mechanisms in place that seem to make the ordering crucial.

For a specific example: Sly Cooper and the Thievius Raccoonus