### PR TITLE
Use rapidyaml 0.11.x

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -55,7 +55,7 @@ if((GCC_VERSION VERSION_EQUAL "9.0" OR GCC_VERSION VERSION_GREATER "9.0") AND GC
 endif()
 
 find_optional_system_library(fmt 3rdparty/fmt/fmt 7.1.3)
-find_optional_system_library(ryml 3rdparty/rapidyaml/rapidyaml 0.4.0)
+find_optional_system_library(ryml 3rdparty/rapidyaml/rapidyaml 0.11.1)
 find_optional_system_library(zstd 3rdparty/zstd 1.4.5)
 if (${zstd_TYPE} STREQUAL System)
 	alias_library(Zstd::Zstd zstd::libzstd_shared)

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -868,9 +868,10 @@ u32 GameDatabaseSchema::GameEntry::applyGSHardwareFixes(Pcsx2Config::GSOptions& 
 void GameDatabase::initDatabase()
 {
 	ryml::Callbacks rymlCallbacks = ryml::get_callbacks();
-	rymlCallbacks.m_error = [](const char* msg, size_t msg_len, ryml::Location loc, void*) {
-		Console.Error("[YAML] Parsing error at {%s}:{%s} (bufpos={%s}): {%s}",
-			loc.line, loc.col, loc.offset, msg);
+	rymlCallbacks.m_error_parse = [](c4::csubstr msg, ryml::ErrorDataParse const& errdata, void*) {
+		Console.Error("[YAML] Parsing error at {%zu}:{%zu} (bufpos={%zu}): {%.*s}",
+			errdata.ymlloc.line, errdata.ymlloc.col, errdata.ymlloc.offset,
+			(int)msg.len, msg.str);
 	};
 	ryml::set_callbacks(rymlCallbacks);
 	c4::set_error_callback([](const char* msg, size_t msg_size) {


### PR DESCRIPTION
Arch linux updated to `rapidyaml` 0.11.x recently, and I noticed that the AUR `libretro-lrps2-git` package system-depends on `rapidyaml` (i.e., it uses the `pacman` installed `rapidyaml` rather than the old (0.4.x) `rapidyaml` from `git submodules`.).

The `m_error` API changed, and hence, after some digging, I changed `m_error` to use `m_error_parse`.