### PR TITLE
CI: add Linux aarch64 build job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,14 @@ libretro-build-linux-x64:
   variables:
     EXTRA_PATH: bin
 
+# Linux 64-bit arm
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+  variables:
+    EXTRA_PATH: bin
+
 # MacOS 64-bit
 libretro-build-osx-x64:
   tags:


### PR DESCRIPTION
Adds a Linux aarch64 build job using the existing `.libretro-linux-cmake-aarch64` template from `libretro-infrastructure/ci-templates` (already included via `linux-cmake.yml`), so the buildbot produces an arm64 Linux core alongside the existing x86_64 one.