### PR TITLE
EE/arm64: restore u32 p cursor dropped by the instrumentation cleanup

### DIFF
--- a/pcsx2/arm64/recR5900_arm64.cpp
+++ b/pcsx2/arm64/recR5900_arm64.cpp
@@ -3372,6 +3372,7 @@ namespace {
 		}
 
 		int n = 0;
+		u32 p = pc; // guest pc cursor advanced across the translated run
 		int cyc = 0; // raw sum of the leading translated ops' cycle costs
 		bool done = false;
 		bool branch_end = false; // ended via EmitBranch: branch + delay slot baked


### PR DESCRIPTION
Commit 24e5639f8 (remove TEMP LRPS2_* JIT/MTVU instrumentation) also deleted the `u32 p = pc;` guest-pc cursor that sat right after a removed debug block in the translated-run emitter of `recR5900_arm64.cpp`, leaving three uses of `p` (memRead32, StorePCImm, Norm) without a declaration:

```
recR5900_arm64.cpp: error: 'p' was not declared in this scope
  3383 | const u32 insn = memRead32(p);
  3419 | StorePCImm(masm, p);
  3470 | const u32 ns = Norm(pc), ne = Norm(branch_end ? p + 8 : p);
```

This breaks the arm64 build. It went unnoticed because arm64 had no CI job — the `libretro-build-linux-aarch64` job added in #144 now surfaces it (pipeline 91794). One-line restore of the cursor.

(The concurrent `libretro-build-linux-x64` failure in that pipeline is unrelated — a Docker image pull TLS-handshake timeout, i.e. transient infra; a retry clears it.)