### PR TITLE
Fix the ARM64 and Windows builds, and add Android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,11 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
+  ################################## CELLULAR ################################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -112,3 +117,22 @@ libretro-build-osx-arm64:
     - .core-defs
   variables:
     EXTRA_PATH: libretro
+
+################################### CELLULAR #################################
+# Android ARMv8a
+# EXTRA_PATH matches the Linux jobs: the top-level CMakeLists redirects the
+# library output to bin/ under `UNIX AND NOT APPLE`, which Android satisfies.
+android-arm64-v8a:
+  extends:
+    - .libretro-android-cmake-arm64-v8a
+    - .core-defs
+  variables:
+    EXTRA_PATH: bin
+
+# Android 64-bit x86
+android-x86_64:
+  extends:
+    - .libretro-android-cmake-x86_64
+    - .core-defs
+  variables:
+    EXTRA_PATH: bin

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -1,14 +1,18 @@
 # All flags, libraries, etc, that are shared between PCSX2 compilation files
 # GameDatabaseBuiltin.cpp is generated from the shipped GameIndex.yaml at
-# build time (tools/gen_gamedb_builtin.sh, POSIX shell + od + awk only),
-# mirroring the static-Makefile rule.
+# build time. Driven through CMake's own script mode rather than the shell
+# version in tools/gen_gamedb_builtin.sh: the MSVC Windows runner has no sh,
+# where the shell rule failed with "'sh' is not recognized as an internal or
+# external command". The .sh stays for the static-Makefile rule, which is
+# POSIX-only anyway - keep the two in sync.
 add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/GameDatabaseBuiltin.cpp
-	COMMAND sh ${CMAKE_SOURCE_DIR}/tools/gen_gamedb_builtin.sh
-		${CMAKE_SOURCE_DIR}/bin/resources/GameIndex.yaml
-		${CMAKE_CURRENT_BINARY_DIR}/GameDatabaseBuiltin.cpp
+	COMMAND ${CMAKE_COMMAND}
+		-DYAML=${CMAKE_SOURCE_DIR}/bin/resources/GameIndex.yaml
+		-DOUT=${CMAKE_CURRENT_BINARY_DIR}/GameDatabaseBuiltin.cpp
+		-P ${CMAKE_SOURCE_DIR}/tools/gen_gamedb_builtin.cmake
 	DEPENDS ${CMAKE_SOURCE_DIR}/bin/resources/GameIndex.yaml
-	        ${CMAKE_SOURCE_DIR}/tools/gen_gamedb_builtin.sh
+	        ${CMAKE_SOURCE_DIR}/tools/gen_gamedb_builtin.cmake
 	COMMENT "Generating GameDatabaseBuiltin.cpp from GameIndex.yaml"
 	VERBATIM)
 

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -15,7 +15,6 @@
 
 
 #include <retro_atomic.h>
-#include <xmmintrin.h>
 #include <cstring> /* memset */
 #include <compat/strl.h>
 
@@ -737,8 +736,8 @@ void ps2_audit_ee_exec(int use_interp, unsigned char* regs_io, unsigned ninstr)
 	}
 	else
 	{
-		const u32 host_csr = _mm_getcsr();
-		_mm_setcsr(EmuConfig.Cpu.FPUFPCR.bitmask);
+		const FPControlRegister host_fpcr = FPControlRegister::GetCurrent();
+		FPControlRegister::SetCurrent(EmuConfig.Cpu.FPUFPCR);
 		/* The exit fires at the first block-boundary event test at or
 		 * beyond nextEventCycle; multi-block programs (branches jump
 		 * between blocks with event tests in between) need a cycle
@@ -746,7 +745,7 @@ void ps2_audit_ee_exec(int use_interp, unsigned char* regs_io, unsigned ninstr)
 		Cpu->ExitExecution();
 		cpuRegs.nextEventCycle = cpuRegs.cycle + ninstr * 2 + 64;
 		Cpu->Execute();
-		_mm_setcsr(host_csr);
+		FPControlRegister::SetCurrent(host_fpcr);
 	}
 	cpuRegs.pc = old_pc;
 	cpuRegs.nextEventCycle = old_cycle_target;

--- a/tools/gen_gamedb_builtin.cmake
+++ b/tools/gen_gamedb_builtin.cmake
@@ -1,0 +1,46 @@
+# Generate GameDatabaseBuiltin.cpp from bin/resources/GameIndex.yaml.
+#
+# Script-mode CMake, so the only dependency is the CMake already running the
+# build. The shell version this replaces needed sh + od + awk, which the MSVC
+# Windows runner does not have ("'sh' is not recognized as an internal or
+# external command").
+#
+# Usage: cmake -DYAML=<in> -DOUT=<out.cpp> -P gen_gamedb_builtin.cmake
+
+if(NOT DEFINED YAML OR NOT DEFINED OUT)
+	message(FATAL_ERROR "YAML and OUT must be set")
+endif()
+
+file(READ "${YAML}" hex HEX)
+if(hex STREQUAL "")
+	message(FATAL_ERROR "${YAML} is empty or unreadable")
+endif()
+
+# "0a1b..." -> "0x0a,0x1b,...", then a newline every 20 bytes so the generated
+# file is not one multi-megabyte line.
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," body "${hex}")
+# CMake's regex has no {n} repetition, so the 20-byte row is spelled out.
+set(row "")
+foreach(i RANGE 1 20)
+	string(APPEND row "0x..,")
+endforeach()
+string(REGEX REPLACE "(${row})" "\\1\n\t" body "${body}")
+
+file(WRITE "${OUT}"
+"// Auto-generated from bin/resources/GameIndex.yaml. Do not edit by hand.
+// Generated at build time by tools/gen_gamedb_builtin.cmake.
+//
+// Embeds the PCSX2 game-compatibility database into the core so it works
+// without an external <systemdir>/resources/GameIndex.yaml.
+
+#include <cstddef>
+
+extern const unsigned char g_gameDatabaseBuiltin[];
+extern const size_t g_gameDatabaseBuiltinSize;
+
+const unsigned char g_gameDatabaseBuiltin[] = {
+\t${body}
+};
+
+const size_t g_gameDatabaseBuiltinSize = sizeof(g_gameDatabaseBuiltin);
+")

--- a/tools/gen_gamedb_builtin.sh
+++ b/tools/gen_gamedb_builtin.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Generate GameDatabaseBuiltin.cpp from bin/resources/GameIndex.yaml.
 # POSIX shell + od + awk only -- no new build dependencies.
+# Used by the static Makefile. The CMake build drives gen_gamedb_builtin.cmake
+# instead, because the MSVC Windows runner has no sh; keep the two in sync.
 # Usage: gen_gamedb_builtin.sh <yaml> <out.cpp>
 set -e
 YAML="$1"; OUT="$2"


### PR DESCRIPTION
Three of the six jobs on [pipeline 104626](https://git.libretro.com/libretro/ps2/-/pipelines/104626) are red, from two unrelated causes. This fixes both and adds Android on top.

### `linux-aarch64` and `osx-arm64` — `xmmintrin.h`

```
pcsx2/R5900.cpp:18:10: fatal error: xmmintrin.h: No such file or directory
```

Worth stressing how close this is: 154 objects compile before it, and that is the *only* error in either job's log. The include is unconditional, and the sole thing it was needed for is the MXCSR save/restore around the audit path's `Execute()`.

`common/FPControl.h` already abstracts precisely that — its own header comment says "MXCSR on x86, and FPCR on AArch64" — and it has a full AArch64 branch with an identical `GetCurrent()` / `SetCurrent()` API. So the fix is to use it and drop the include.

Passing the `FPControlRegister` rather than its `.bitmask` keeps this off the member, which is `u32` on x86 and `u64` on AArch64. `Config.h` already includes `common/FPControl.h`, so nothing new is included. On x86 there is no behaviour change at all: `GetCurrent()`/`SetCurrent()` *are* `_mm_getcsr()`/`_mm_setcsr()` there.

### `windows-x64` — no `sh` on the MSVC runner

```
Generating GameDatabaseBuiltin.cpp from GameIndex.yaml
'sh' is not recognized as an internal or external command
error MSB8066: Custom build ... exited with code 9009
```

The custom command shells out to `tools/gen_gamedb_builtin.sh`, and the MSVC runner has no `sh` (nor `od` or `awk`). The same generation now runs through CMake's script mode, so the only dependency is the CMake already running the build.

I checked this against the shell version on the shipped `GameIndex.yaml`: both emit **1819912 bytes**, matching the input file exactly, and the two byte sequences are identical under `cmp`. The generated `.cpp` also passes a compile check.

The `.sh` stays for the static-Makefile rule, which is POSIX-only anyway; both files now carry a note to keep them in sync.

One CMake wrinkle worth recording for whoever touches this next: its regex flavour has no `{n}` repetition. Written the obvious way, the 20-bytes-per-row split silently does nothing and the array comes out as a single 9MB line — the file still generates and still compiles, so it is easy to miss. The row pattern is therefore built by repeating in a loop.

### Android

`arm64-v8a` and `x86_64`, via `android-cmake.yml`. Its jobs are stage `build-shared`, already in the stages list, so nothing else moves.

`EXTRA_PATH` is `bin`, matching the Linux jobs rather than the macOS ones: the top-level `CMakeLists.txt` redirects library output to `bin/` under `UNIX AND NOT APPLE`, which Android satisfies. The template's `after_script` moves the artifact out of `$BUILD_DIR/$EXTRA_PATH`, so getting this wrong would build fine and then ship nothing.

### What I have not verified

I cannot build any of these targets here. The two fixes each remove the *first* error in their job, not necessarily the last — there may well be more x86-isms behind the ARM64 one — and the two Android jobs have never run at all. The `sh` replacement is the one piece verified directly, by output comparison rather than by a build.
