### PR TITLE
cmake: bionic has no librt

### DIFF
--- a/cmake/FindLibc.cmake
+++ b/cmake/FindLibc.cmake
@@ -10,7 +10,12 @@ endif(LIBC_LIBRARIES)
 find_library(libm NAMES m)
 
 # OSX doesn't have rt. On Linux timer and aio dependency.
-if(APPLE)
+if(ANDROID)
+	# bionic has neither librt nor libdl: the timer and dl entry points live in
+	# libc itself. Looking for them leaves librt-NOTFOUND in LIBC_LIBRARIES,
+	# which CMake then refuses to generate a link line for.
+	set(LIBC_LIBRARIES ${libm})
+elseif(APPLE)
 	find_library(libdl NAMES dl)
 	set(LIBC_LIBRARIES ${librt} ${libdl} ${libm})
 elseif(Linux)


### PR DESCRIPTION
The android jobs I added in #154 have never got past configure. First it was `find_package(OpenGL REQUIRED)`, fixed in f5e47ce3a; now it is one line further along:

```
CMake Error: The following variables are used in this project, but they are
set to NOTFOUND: librt, linked by target "common"
```

`cmake/FindLibc.cmake` looks for `rt` and `dl` on everything that is not APPLE — the `elseif(Linux)` arm tests a variable nobody ever sets, so Linux falls into the `else()` too. Android has neither: bionic folds the timer and dl entry points into libc. `find_library` therefore leaves `librt-NOTFOUND` in `LIBC_LIBRARIES`, and generation stops.

Everything else on [pipeline 104926](https://git.libretro.com/libretro/ps2/-/pipelines/104926) is green now, including windows-x64 after 02d30cbb6, so this is the last one standing.

No other platform changes behaviour: Linux was already falling through to the `else()` arm and still does, APPLE and the BSD/else arms are untouched. I have not build-tested this locally — the android NDK is not installed here — so the pipeline is the check.
