### PR TITLE
GS: memfd for the wrapped-memory fd on Android

### DIFF
--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -718,16 +718,30 @@ void GSFreeWrappedMemory(void* ptr, size_t size, size_t repeat)
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifdef __ANDROID__
+#include <sys/syscall.h> /* memfd_create via syscall: bionic has no shm_open */
+#endif
 
 static int s_shm_fd = -1;
 
 void* GSAllocateWrappedMemory(size_t size, size_t repeat)
 {
 	const char* file_name = "/GS.mem";
+#ifdef __ANDROID__
+	/* Same as HostSys::CreateSharedMemory: bionic has no shm_open, and the
+	 * mapping is anonymous anyway since the name is unlinked right after
+	 * creation, so a memfd is a drop-in. Called via syscall so it builds on
+	 * every API level the NDK lanes target; 1U is MFD_CLOEXEC, spelled
+	 * literally to avoid a linux/memfd.h dependency on older sysroots. */
+	s_shm_fd = static_cast<int>(syscall(__NR_memfd_create, file_name, 1U /* MFD_CLOEXEC */));
+	if (s_shm_fd == -1)
+		return nullptr;
+#else
 	s_shm_fd = shm_open(file_name, O_RDWR | O_CREAT | O_EXCL, 0600);
 	if (s_shm_fd == -1)
 		return nullptr;
 	shm_unlink(file_name); // file is deleted but descriptor is still open
+#endif
 
 	if (ftruncate(s_shm_fd, repeat * size) < 0)
 		fprintf(stderr, "Failed to reserve memory due to %s\n", strerror(errno));


### PR DESCRIPTION
Follow-up to 041fce612, from [pipeline 104940](https://git.libretro.com/libretro/ps2/-/pipelines/104940). That commit gave `HostSys::CreateSharedMemory` a memfd; `GSAllocateWrappedMemory` is the other `shm_open` in the tree, and the android lanes now stop there instead:

```
pcsx2/GS/GS.cpp:727:13: error: use of undeclared identifier 'shm_open'
pcsx2/GS/GS.cpp:730:2: error: use of undeclared identifier 'shm_unlink'
```

Same shape as the one you already fixed — the name is `shm_unlink`ed on the line after it is created, so the mapping is anonymous and a memfd behaves identically. The repeat-mmap loop underneath operates on a plain fd and needs no changes. Called through `syscall` for the same reason, with `MFD_CLOEXEC` spelled as `1U`.

I grepped the rest of `pcsx2/` and `common/`: these two call sites were the only `shm_open` users outside 3rdparty, so this should be the end of that particular thread.

Everything else on that pipeline is green — windows-x64, linux x64/aarch64, osx x64/arm64 — so android is the last one out.

Not build-tested locally (no NDK here); the pipeline is the check.
